### PR TITLE
manage service

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,12 @@
 fixtures:
   repositories:
+    apt:
+      repo: 'git://github.com/puppetlabs/puppetlabs-apt.git'
+      ref: '1.4.2'
     stdlib:
       repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
       ref: '3.2.0'
+    zypprepo:
+      repo: 'git://github.com/deadpoint/puppet-zypprepo.git'
   symlinks:
     vmware: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,7 @@ fixtures:
       ref: '1.4.2'
     stdlib:
       repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
-      ref: '3.2.0'
+      ref: '4.2.0'
     zypprepo:
       repo: 'git://github.com/deadpoint/puppet-zypprepo.git'
   symlinks:

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,8 @@ doc/
 # Puppet
 coverage/
 spec/fixtures/modules/*
-spec/fixtures
+spec/fixtures/manifests/*
+Gemfile.lock
+
+# Geppetto
+.project

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@ source 'https://rubygems.org'
 
 puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 3.3']
 gem 'puppet', puppetversion
+if RUBY_VERSION.start_with? '1.8'
+ gem 'rspec', '~> 3.1.0'
+end
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 0.3.2'
 gem 'facter', '>= 1.7.0', "< 1.8.0"

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppet-module-vmware'
-version '0.2.0'
+version '1.0.0'
 source 'git://github.com/emahags/puppet-module-vmware.git'
 author 'emahags'
 license 'Apache License, Version 2.0'

--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ String to pass to ensure attribute for the vmwaretools nox package.
 
 - *Default*: 'present'
 
+manage_service
+--------------
+If vmwaretools service should be managed (boolean)
+
+- *Default*: true
+
+service_name
+------------
+Service name to manage (string).
+
+- *Default*: 'USE_DEFAULTS', based on OS platform
+
 manage_tools_x_package
 ----------------------
 Should vmwaretools x package be managed?

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Build Status](https://travis-ci.org/emahags/puppet-module-vmware.png?branch=master)](https://travis-ci.org/emahags/puppet-module-vmware)
 
-Manage VMware - Install vmwaretools. Will remove vmware tools that has been installed from script if present. Will use open-vm-tools by default on RHEL 7 and SUSE 12, for all other the default is VMware OSP packages.
+Manage VMware - Install vmwaretools. Will remove vmware tools that has been installed from script if present. Will use open-vm-tools by default on RHEL 7+, SUSE 12+, and Ubuntu 12+, for all other the default is VMware OSP packages.
 
 ===
 
@@ -11,74 +11,80 @@ Manage VMware - Install vmwaretools. Will remove vmware tools that has been inst
 
 ## Parameters
 
-manage_repo_package
--------------------
-Should repo package be managed? Contains the vmware repo and key.
+manage_repo
+-----------
+Should repo file be managed?
 
 - *Default*: default is set based on OS version
 
-repo_package_name
+repo_base_url
+---------------------
+Base URL of mirror of packages.vmware.com/tools/esx.
+
+- *Default*: http://packages.vmware.com/tools/esx
+
+esx_version
+-----------
+Version of ESX (e.g. 5.1, 5.5, 5.5ep06) ... note, it is recommended to explicitly set the esx version rather than default to latest.
+
+- *Default*: latest
+
+gpgkey_url
+----------
+URL for VMware GPG key
+
+- *Default*: http://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub
+
+proxy_host
+----------
+Hostname of web proxy (not supported on SUSE)
+
+- *Default*: absent
+
+proxy_port
+----------
+Port number of web proxy
+
+- *Default*: 8080
+
+prefer_open_vm_tools
 -----------------
-Name of repo package. Please note that this needs to be built manually, there is no premade package.
+Prefer open-vm-tools over vmware-tools in the case that both are available (e.g. Ubuntu 12.04).
 
-- *Default*: 'vmwaretools-repo'
-
-repo_package_ensure
--------------------
-String to pass to ensure attribute for the repo package.
-
-- *Default*: 'present'
+- *Default*: true
 
 manage_tools_nox_package
---------------------
+------------------------
 Should vmwaretools nox package be managed?
 
 - *Default*: true
 
 tools_nox_package_name
-------------------
+----------------------
 Name of package for vmwaretools nox package.
 
 - *Default*: default is set based on OS version
 
 tools_nox_package_ensure
---------------------
+------------------------
 String to pass to ensure attribute for the vmwaretools nox package.
 
 - *Default*: 'present'
 
 manage_tools_x_package
---------------------
+----------------------
 Should vmwaretools x package be managed?
 
 - *Default*: based on if X is installed or not.
 
 tools_x_package_name
-------------------
+--------------------
 Name of package for vmwaretools x package.
 
 - *Default*: default is set based on OS version
 
 tools_x_package_ensure
---------------------
+----------------------
 String to pass to ensure attribute for the vmwaretools x package.
-
-- *Default*: 'present'
-
-manage_tools_kmod_package
---------------------
-Should vmwaretools kmod package be managed?
-
-- *Default*: default is set based on OS version
-
-tools_kmod_package_name
-------------------
-Name of package for vmwaretools kmod package.
-
-- *Default*: default is set based on OS version
-
-tools_kmod_package_ensure
---------------------
-String to pass to ensure attribute for the vmwaretools kmod package.
 
 - *Default*: 'present'

--- a/lib/facter/vmware_has_x.rb
+++ b/lib/facter/vmware_has_x.rb
@@ -2,9 +2,9 @@ Facter.add(:vmware_has_x) do
   confine :virtual => 'vmware'
   setcode do
     if Facter::Util::Resolution.exec("which X >/dev/null 2>&1 || which Xorg >/dev/null 2>&1 && echo 'true'") == 'true'
-      'true'
+      true
     else
-      'false'
+      false
     end
   end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,42 +3,100 @@
 # Manage vmware
 #
 class vmware (
-  $manage_repo_package       = 'USE_DEFAULTS',
+  $manage_repo               = 'USE_DEFAULTS',
+  $repo_base_url             = 'http://packages.vmware.com/tools/esx',
+  $esx_version               = 'latest',
+  $gpgkey_url                = 'http://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub',
+  $proxy_host                = 'absent',
+  $proxy_port                = '8080',
+  $prefer_open_vm_tools      = true,
   $manage_tools_nox_package  = true,
-  $manage_tools_kmod_package = 'USE_DEFAULTS',
   $manage_tools_x_package    = 'USE_DEFAULTS',
-  $repo_package_name         = 'vmwaretools-repo',
   $tools_nox_package_name    = 'USE_DEFAULTS',
-  $tools_kmod_package_name   = 'USE_DEFAULTS',
   $tools_x_package_name      = 'USE_DEFAULTS',
-  $repo_package_ensure       = 'present',
   $tools_nox_package_ensure  = 'present',
-  $tools_kmod_package_ensure = 'present',
   $tools_x_package_ensure    = 'present',
 ){
 
-  validate_string($repo_package_name)
-  validate_string($repo_package_ensure)
+  validate_string($repo_base_url)
+  validate_string($esx_version)
+  validate_string($gpgkey_url)
+  validate_string($proxy_host)
+  validate_string($proxy_port)
   validate_string($tools_nox_package_ensure)
   validate_string($tools_nox_package_name)
   validate_string($tools_x_package_ensure)
   validate_string($tools_x_package_name)
-  validate_string($tools_kmod_package_ensure)
-  validate_string($tools_kmod_package_name)
+
 
   if $::virtual == 'vmware' {
-    if $manage_repo_package == 'USE_DEFAULTS' {
-      if ($::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7') or ($::osfamily == 'Suse' and $::lsbmajdistrelease == '12') {
-        $manage_repo_package_real = false
+
+    if is_string($prefer_open_vm_tools) == true {
+      $prefer_open_vm_tools_real = str2bool($prefer_open_vm_tools)
+    } else {
+      validate_bool($prefer_open_vm_tools)
+      $prefer_open_vm_tools_real = $prefer_open_vm_tools
+    }
+
+    # OSs that have open-vm-tools
+    case $::operatingsystem {
+      'RedHat', 'CentOS': {
+        $_use_open_vm_tools = $::lsbmajdistrelease >= 7
+      }
+      'SLED', 'SLES': {
+        $_use_open_vm_tools = $::lsbmajdistrelease >= 12
+      }
+      'OpenSuSE': {
+        $_use_open_vm_tools = $::lsbmajdistrelease >= 12
+      }
+      'Ubuntu': {
+        if $prefer_open_vm_tools_real == true {
+          # include Ubuntu 12.04
+          $_use_open_vm_tools = $::lsbmajdistrelease >= 12
+        } else {
+          # skip Ubuntu 12.04
+          $_use_open_vm_tools = $::lsbmajdistrelease > 12
+        }
+      }
+      default: {
+          fail("The vmware module is not supported on ${::operatingsystem}")
+      }
+    }
+
+    if $_use_open_vm_tools == true {
+      $_tools_nox_package_name_default = 'open-vm-tools'
+
+      case $::operatingsystem {
+        'RedHat', 'CentOS': {
+          $_tools_x_package_name_default = 'open-vm-tools-desktop'
+        }
+        'SLES', 'SLES', 'OpenSuSE': {
+          $_tools_x_package_name_default = 'open-vm-tools-gui'
+        }
+        'Ubuntu': {
+          $_tools_x_package_name_default = 'open-vm-toolbox'
+        }
+        default: {
+          fail("The vmware module is not supported on ${::operatingsystem}")
+        }
+      }
+    } else { # assume vmware-tools exists for OS
+      $_tools_nox_package_name_default = 'vmware-tools-esx-nox'
+      $_tools_x_package_name_default   = 'vmware-tools-esx'
+    }
+
+    if $manage_repo == 'USE_DEFAULTS' {
+      if $_use_open_vm_tools {
+        $manage_repo_real = false
       } else {
-        $manage_repo_package_real = true
+        $manage_repo_real = true
       }
     } else {
-      if is_string($manage_repo_package) == true {
-        $manage_repo_package_real = str2bool($manage_repo_package)
+      if is_string($manage_repo) == true {
+        $manage_repo_real = str2bool($manage_repo)
       } else {
-        validate_bool($manage_repo_package)
-        $manage_repo_package_real = $manage_repo_package
+        validate_bool($manage_repo)
+        $manage_repo_real = $manage_repo
       }
     }
 
@@ -47,21 +105,6 @@ class vmware (
     } else {
       validate_bool($manage_tools_nox_package)
       $manage_tools_nox_package_real = $manage_tools_nox_package
-    }
-
-    if $manage_tools_kmod_package == 'USE_DEFAULTS' {
-      if ($::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7') or ($::osfamily == 'Suse' and $::lsbmajdistrelease == '12') {
-        $manage_tools_kmod_package_real = false
-      } else {
-        $manage_tools_kmod_package_real = true
-      }
-    } else {
-      if is_string($manage_tools_kmod_package) == true {
-        $manage_tools_kmod_package_real = str2bool($manage_tools_kmod_package)
-      } else {
-        validate_bool($manage_tools_kmod_package)
-        $manage_tools_kmod_package_real = $manage_tools_kmod_package
-      }
     }
 
     if $::vmware_has_x == 'true' and $manage_tools_x_package == 'USE_DEFAULTS' {
@@ -77,46 +120,98 @@ class vmware (
       }
     }
 
-    if $manage_repo_package_real == true {
-      package { $repo_package_name:
-        ensure => $repo_package_ensure,
+    if $manage_repo_real == true {
+
+      case $::operatingsystem {
+        'RedHat', 'CentOS': {
+
+          if $proxy_host == 'absent' {
+            $_proxy = undef
+          } else {
+            $_proxy = "http://${proxy_host}:${proxy_port}"
+          }
+
+          yumrepo { 'vmware-osps':
+            baseurl  => "${repo_base_url}/${esx_version}/rhel${::operatingsystemmajrelease}/${::architecture}",
+            enabled  => 1,
+            gpgcheck => 1,
+            gpgkey   => $gpgkey_url,
+            proxy    => $_proxy,
+          }
+        }
+
+        'SLED', 'SLES', 'OpenSuSE': {
+          include zypprepo
+
+          if $proxy_host != 'absent' {
+            fail("The vmware::proxy_host parameter is not supported on ${::operatingsystem}")
+          }
+
+          case $::operatingsystemrelease {
+            /^10./: {
+              $_suseos = '10'
+            }
+            default: {
+              $_suseos = $::operatingsystemrelease
+            }
+          }
+
+          zypprepo { 'vmware-osps':
+            enabled     => 1,
+            autorefresh => 0,
+            baseurl     => "${repo_base_url}/${esx_version}/sles${_suseos}/${::architecture}",
+            path        => '/',
+            type        => 'yum',
+            gpgcheck    => 1,
+            gpgkey      => $gpgkey_url,
+          }
+        }
+        'Ubuntu': {
+
+          if $proxy_host == 'absent' {
+            include apt
+          } else {
+            # will only work if apt is not already defined elsewhere
+            class { 'apt':
+              proxy_host => $proxy_host,
+              proxy_port => '8080',
+            }
+          }
+
+          apt::key { 'vmware':
+            key        => 'C0B5E0AB66FD4949',
+            key_source => $gpgkey_url,
+          }
+
+          apt::source { 'vmware-osps':
+            location    => "${repo_base_url}/${esx_version}/ubuntu",
+            release     => $::lsbdistcodename,
+            repos       => 'main',
+            include_src => false,
+          }
+        }
+        default: {
+          fail("The vmware module is not supported on ${::operatingsystem}")
+        }
       }
     }
 
     if $tools_nox_package_name == 'USE_DEFAULTS' {
-      if ($::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7') or ($::osfamily == 'Suse' and $::lsbmajdistrelease == '12') {
-        $tools_nox_package_name_real = 'open-vm-tools'
-      } else {
-        $tools_nox_package_name_real = 'vmware-tools-esx-nox'
-      }
+      $tools_nox_package_name_real = $_tools_nox_package_name_default
     } else {
       $tools_nox_package_name_real = $tools_nox_package_name
     }
 
-    if $tools_kmod_package_name == 'USE_DEFAULTS' {
-      if ($::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7') or ($::osfamily == 'Suse' and $::lsbmajdistrelease == '12') {
-        $tools_kmod_package_name_real = 'open-vm-tools'
-      } else {
-        $tools_kmod_package_name_real = 'vmware-tools-esx-kmods'
-      }
-    } else {
-      $tools_kmod_package_name_real = $tools_kmod_package_name
-    }
-
     if $tools_x_package_name == 'USE_DEFAULTS' {
-      if ($::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7') or ($::osfamily == 'Suse' and $::lsbmajdistrelease == '12') {
-        $tools_x_package_name_real = 'open-vm-tools-desktop'
-      } else {
-        $tools_x_package_name_real = 'vmware-tools-esx'
-      }
+      $tools_x_package_name_real = $_tools_x_package_name_default
     } else {
       $tools_x_package_name_real = $tools_x_package_name
     }
 
-    if $manage_tools_nox_package_real == true or $manage_tools_x_package_real == true or $manage_tools_kmod_package_real == true {
+    if $manage_tools_nox_package_real == true or $manage_tools_x_package_real == true {
       exec { 'Remove vmware tools script installation':
-        path => '/usr/bin/:/etc/vmware-tools/',
-        onlyif => 'test -e "/etc/vmware-tools/locations" -a ! -e "/usr/lib/vmware-tools/dsp"',
+        path    => '/usr/bin/:/etc/vmware-tools/',
+        onlyif  => 'test -e "/etc/vmware-tools/locations" -a ! -e "/usr/lib/vmware-tools/dsp"',
         command => 'installer.sh uninstall',
       }
       if $manage_tools_nox_package_real == true {
@@ -125,35 +220,17 @@ class vmware (
       if $manage_tools_x_package_real == true {
         Exec['Remove vmware tools script installation'] -> Package[$tools_x_package_name_real]
       }
-      if $manage_tools_kmod_package_real == true {
-        Exec['Remove vmware tools script installation'] -> Package[$tools_kmod_package_name_real]
-      }
     }
 
     if $manage_tools_nox_package_real == true {
       package { $tools_nox_package_name_real:
         ensure => $tools_nox_package_ensure,
       }
-      if $manage_repo_package_real == true {
-        Package[$repo_package_name] -> Package[$tools_nox_package_name_real]
-      }
     }
 
     if $manage_tools_x_package_real == true {
       package { $tools_x_package_name_real:
         ensure => $tools_x_package_ensure,
-      }
-      if $manage_repo_package_real == true {
-        Package[$repo_package_name] -> Package[$tools_x_package_name_real]
-      }
-    }
-
-    if $manage_tools_kmod_package_real == true {
-      package { $tools_kmod_package_name_real:
-        ensure => $tools_kmod_package_ensure,
-      }
-      if $manage_repo_package_real == true {
-        Package[$repo_package_name] -> Package[$tools_kmod_package_name_real]
       }
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,8 @@ class vmware (
   $proxy_host                = 'absent',
   $proxy_port                = '8080',
   $prefer_open_vm_tools      = true,
+  $manage_service            = true,
+  $service_name              = 'USE_DEFAULTS',
   $manage_tools_nox_package  = true,
   $manage_tools_x_package    = 'USE_DEFAULTS',
   $tools_nox_package_name    = 'USE_DEFAULTS',
@@ -23,6 +25,7 @@ class vmware (
   validate_string($gpgkey_url)
   validate_string($proxy_host)
   validate_string($proxy_port)
+  validate_string($service_name)
   validate_string($tools_nox_package_ensure)
   validate_string($tools_nox_package_name)
   validate_string($tools_x_package_ensure)
@@ -69,12 +72,15 @@ class vmware (
       case $::operatingsystem {
         'RedHat', 'CentOS': {
           $_tools_x_package_name_default = 'open-vm-tools-desktop'
+          $_service_name_default         = 'vmtoolsd'
         }
         'SLES', 'SLES', 'OpenSuSE': {
           $_tools_x_package_name_default = 'open-vm-tools-gui'
+          $_service_name_default         = 'vmtoolsd'
         }
         'Ubuntu': {
           $_tools_x_package_name_default = 'open-vm-toolbox'
+          $_service_name_default         = 'open-vm-tools'
         }
         default: {
           fail("The vmware module is not supported on ${::operatingsystem}")
@@ -83,6 +89,7 @@ class vmware (
     } else { # assume vmware-tools exists for OS
       $_tools_nox_package_name_default = 'vmware-tools-esx-nox'
       $_tools_x_package_name_default   = 'vmware-tools-esx'
+      $_service_name_default           = 'vmware-tools-services'
     }
 
     if $manage_repo == 'USE_DEFAULTS' {
@@ -233,5 +240,33 @@ class vmware (
         ensure => $tools_x_package_ensure,
       }
     }
+
+    if is_bool($manage_service) == true {
+      $manage_service_real = $manage_service
+    } else {
+      $manage_service_real = str2bool($manage_service)
+    }
+
+    if $service_name == 'USE_DEFAULTS' {
+      $service_name_real = $_service_name_default
+    } else {
+      $service_name_real = $tools_nox_package_name
+    }
+
+    if $manage_service_real == true {
+      # workaround for Ubuntu which does not provide the service status
+      if $::operatingsystem == 'Ubuntu' {
+        Service [$service_name_real] {
+          hasstatus => 'false',
+          status    => '/bin/ps -ef | /bin/grep -i "vmtoolsd" | /bin/grep -v "grep"',
+        }
+      }
+
+      service { $service_name_real:
+        ensure => 'running',
+        require => Package[$tools_nox_package_name_real],
+      }
+    }
+
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -31,6 +31,12 @@ describe 'vmware' do
            'proxy' => 'undef',
          })
       }
+      it {
+        should contain_service('vmware-tools-services').with({
+           'ensure'  => 'running',
+           'require' => 'Package[vmware-tools-esx-nox]',
+        })
+      }
     end
 
     context 'on machine with X installed' do
@@ -70,6 +76,12 @@ describe 'vmware' do
       }
       it {
         should_not contain_yumrepo('vmware-osps')
+      }
+      it {
+        should contain_service('vmtoolsd').with({
+           'ensure'  => 'running',
+           'require' => 'Package[open-vm-tools]',
+        })
       }
     end
 
@@ -120,6 +132,12 @@ describe 'vmware' do
            'gpgcheck' => '1',
            'gpgkey' => 'http://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub',
          })
+      }
+      it {
+        should contain_service('vmware-tools-services').with({
+           'ensure'  => 'running',
+           'require' => 'Package[vmware-tools-esx-nox]',
+        })
       }
     end
 
@@ -172,6 +190,12 @@ describe 'vmware' do
            'gpgkey' => 'http://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub',
          })
       }
+      it {
+        should contain_service('vmware-tools-services').with({
+           'ensure' => 'running',
+           'require' => 'Package[vmware-tools-esx-nox]',
+        })
+      }
     end
 
     context 'on machine with X installed' do
@@ -213,6 +237,11 @@ describe 'vmware' do
       it {
         should_not contain_zypprepo('vmware-osps')
       }
+      it {
+        should contain_service('vmtoolsd').with({
+           'ensure' => 'running',
+        })
+      }
     end
 
     context 'on machine with X installed' do
@@ -252,6 +281,13 @@ describe 'vmware' do
       }
       it {
         should_not contain_class('apt')
+      }
+      it {
+        should contain_service('open-vm-tools').with({
+           'ensure'    => 'running',
+           'hasstatus' => 'false',
+           'status'    => '/bin/ps -ef | /bin/grep -i "vmtoolsd" | /bin/grep -v "grep"',
+        })
       }
     end
 
@@ -300,6 +336,12 @@ describe 'vmware' do
             'repos'       => 'main',
             'include_src' => false,
          })
+      }
+      it {
+        should contain_service('vmware-tools-services').with({
+           'ensure'  => 'running',
+           'require' => 'Package[vmware-tools-esx-nox]',
+        })
       }
     end
 
@@ -359,6 +401,12 @@ describe 'vmware' do
     it { should_not contain_package('vmware-tools-esx') }
     it { should_not contain_package('vmware-tools-esx-nox') }
     it { should_not contain_exec('Remove vmware tools script installation') }
+    it {
+      should contain_service('vmware-tools-services').with({
+         'ensure'  => 'running',
+         'require' => 'Package[vmware-tools-esx-nox]',
+      })
+    }
   end
 
   context 'on a machine that does not run on vmware' do
@@ -372,6 +420,7 @@ describe 'vmware' do
     it { should_not contain_package('vmware-tools-esx') }
     it { should_not contain_package('vmware-tools-esx-nox') }
     it { should_not contain_exec('Remove vmware tools script installation') }
+    it { should_not contain_service('vmware-tools-services') }
   end
 
   describe 'with incorrect types' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -4,14 +4,15 @@ describe 'vmware' do
   describe 'with defaults for all parameters on machine running on vmware' do
     context 'on machine without X installed' do
       let(:facts) do
-        { :virtual      => 'vmware',
-          :vmware_has_x => 'false',
+        { :virtual           => 'vmware',
+          :vmware_has_x      => 'false',
+	  :operatingsystem   => 'RedHat',
+          :lsbmajdistrelease => '6',
+          :architecture      => 'x86_64',
         }
       end
 
-      it { should contain_package('vmwaretools-repo').with('ensure' => 'present') }
       it { should contain_package('vmware-tools-esx-nox').with('ensure' => 'present') }
-      it { should contain_package('vmware-tools-esx-kmods').with('ensure' => 'present') }
       it { should_not contain_package('vmware-tools-esx') }
       it {
         should contain_exec('Remove vmware tools script installation').with({
@@ -20,12 +21,24 @@ describe 'vmware' do
           'onlyif' => 'test -e "/etc/vmware-tools/locations" -a ! -e "/usr/lib/vmware-tools/dsp"',
         })
       }
+      it {
+        should contain_yumrepo('vmware-osps').with
+        ({
+           'baseurl' => 'http://packages.vmware.com/tools/esx/latest/rhel6/x86_64',
+           'enabled' => '1',
+           'gpgcheck' => '1',
+           'gpgkey' => 'http://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub',
+           'proxy' => 'undef',
+         })
+      }
     end
 
     context 'on machine with X installed' do
       let(:facts) do
-        { :virtual => 'vmware',
-          :vmware_has_x => 'true',
+        { :virtual           => 'vmware',
+          :vmware_has_x      => 'true',
+	  :operatingsystem   => 'RedHat',
+          :lsbmajdistrelease => '6',
         }
       end
 
@@ -36,19 +49,17 @@ describe 'vmware' do
   describe 'with defaults for all parameters on RHEL 7 running on vmware' do
     context 'on machine without X installed' do
       let(:facts) do
-        { :virtual                   => 'vmware',
-          :vmware_has_x              => 'false',
-          :osfamily                  => 'RedHat',
-          :operatingsystemmajrelease => '7',
+        { :virtual           => 'vmware',
+          :vmware_has_x      => 'false',
+          :operatingsystem   => 'RedHat',
+          :lsbmajdistrelease => '7',
         }
       end
 
       it { should contain_package('open-vm-tools').with('ensure' => 'present') }
       it { should_not contain_package('open-vm-tools-desktop') }
 
-      it { should_not contain_package('vmwaretools-repo') }
       it { should_not contain_package('vmware-tools-esx-nox') }
-      it { should_not contain_package('vmware-tools-esx-kmods') }
       it { should_not contain_package('vmware-tools-esx') }
       it {
         should contain_exec('Remove vmware tools script installation').with({
@@ -57,44 +68,8 @@ describe 'vmware' do
           'onlyif' => 'test -e "/etc/vmware-tools/locations" -a ! -e "/usr/lib/vmware-tools/dsp"',
         })
       }
-    end
-
-    context 'on machine with X installed' do
-      let(:facts) do
-        { :virtual                   => 'vmware',
-          :vmware_has_x              => 'true',
-          :osfamily                  => 'RedHat',
-          :operatingsystemmajrelease => '7',
-        }
-      end
-
-      it { should contain_package('open-vm-tools-desktop').with('ensure' => 'present') }
-    end
-  end
-
-  describe 'with defaults for all parameters on SUSE 12 running on vmware' do
-    context 'on machine without X installed' do
-      let(:facts) do
-        { :virtual           => 'vmware',
-          :vmware_has_x      => 'false',
-          :osfamily          => 'Suse',
-          :lsbmajdistrelease => '12',
-        }
-      end
-
-      it { should contain_package('open-vm-tools').with('ensure' => 'present') }
-      it { should_not contain_package('open-vm-tools-desktop') }
-
-      it { should_not contain_package('vmwaretools-repo') }
-      it { should_not contain_package('vmware-tools-esx-nox') }
-      it { should_not contain_package('vmware-tools-esx-kmods') }
-      it { should_not contain_package('vmware-tools-esx') }
       it {
-        should contain_exec('Remove vmware tools script installation').with({
-          'command' => 'installer.sh uninstall',
-          'path' => '/usr/bin/:/etc/vmware-tools/',
-          'onlyif' => 'test -e "/etc/vmware-tools/locations" -a ! -e "/usr/lib/vmware-tools/dsp"',
-        })
+        should_not contain_yumrepo('vmware-osps')
       }
     end
 
@@ -102,8 +77,8 @@ describe 'vmware' do
       let(:facts) do
         { :virtual           => 'vmware',
           :vmware_has_x      => 'true',
-          :osfamily          => 'Suse',
-          :lsbmajdistrelease => '12',
+          :operatingsystem   => 'RedHat',
+          :lsbmajdistrelease => '7',
         }
       end
 
@@ -111,39 +86,256 @@ describe 'vmware' do
     end
   end
 
-  context 'with custom values for parameters on machine running on vmware' do
-    let(:facts) do
-      { :virtual => 'vmware',
-        :vmware_has_x => 'true',
+  describe 'with defaults for all parameters on SLES 10 running on vmware' do
+    context 'on machine without X installed' do
+      let(:facts) do
+        { :virtual                => 'vmware',
+          :vmware_has_x           => 'false',
+          :operatingsystem        => 'SLES',
+          :lsbmajdistrelease      => '11',
+          :operatingsystemrelease => '10.2',
+          :architecture           => 'x86_64',
+        }
+      end
+
+      it { should_not contain_package('open-vm-tools') }
+      it { should_not contain_package('open-vm-tools-desktop') }
+
+      it { should contain_package('vmware-tools-esx-nox').with('ensure' => 'present') }
+      it { should_not contain_package('vmware-tools-esx') }
+      it {
+        should contain_exec('Remove vmware tools script installation').with({
+           'command' => 'installer.sh uninstall',
+           'path' => '/usr/bin/:/etc/vmware-tools/',
+           'onlyif' => 'test -e "/etc/vmware-tools/locations" -a ! -e "/usr/lib/vmware-tools/dsp"',
+        })
       }
-    end
-    let(:params) do
-      { :repo_package_name => 'vmwaretools-key-custom',
-        :repo_package_ensure => 'latest',
-        :tools_nox_package_name => 'vmware-tools-esx-nox-custom',
-        :tools_nox_package_ensure => '0.2-1',
-        :tools_x_package_name => 'vmware-tools-esx-custom',
-        :tools_x_package_ensure => '0.3-1',
-        :tools_kmod_package_name => 'vmware-tools-esx-kmods-custom',
-        :tools_kmod_package_ensure => '0.4-1',
+      it {
+        should contain_zypprepo('vmware-osps').with({
+           'enabled'     => '1',
+           'autorefresh' => '0',
+           'baseurl' => 'http://packages.vmware.com/tools/esx/latest/sles10/x86_64',
+           'path'        => '/',
+           'type'        => 'yum',
+           'gpgcheck' => '1',
+           'gpgkey' => 'http://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub',
+         })
       }
     end
 
-    it { should contain_package('vmwaretools-key-custom').with( 'ensure' => 'latest') }
+    context 'on machine with X installed' do
+      let(:facts) do
+        { :virtual                => 'vmware',
+          :vmware_has_x           => 'true',
+          :operatingsystem        => 'SLES',
+          :lsbmajdistrelease      => '10',
+        }
+      end
+
+      it { should contain_package('vmware-tools-esx-nox').with('ensure' => 'present') }
+
+    end
+  end
+
+  describe 'with defaults for all parameters on SLES 11 running on vmware' do
+    context 'on machine without X installed' do
+      let(:facts) do
+        { :virtual                => 'vmware',
+          :vmware_has_x           => 'false',
+          :operatingsystem        => 'SLES',
+          :lsbmajdistrelease      => '11',
+          :operatingsystemrelease => '11.2',
+          :architecture           => 'x86_64',
+        }
+      end
+
+      it { should_not contain_package('open-vm-tools') }
+      it { should_not contain_package('open-vm-tools-desktop') }
+
+      it { should contain_package('vmware-tools-esx-nox').with('ensure' => 'present') }
+      it { should_not contain_package('vmware-tools-esx') }
+      it {
+        should contain_exec('Remove vmware tools script installation').with({
+           'command' => 'installer.sh uninstall',
+           'path' => '/usr/bin/:/etc/vmware-tools/',
+           'onlyif' => 'test -e "/etc/vmware-tools/locations" -a ! -e "/usr/lib/vmware-tools/dsp"',
+        })
+      }
+      it {
+        should contain_zypprepo('vmware-osps').with({
+           'enabled'     => '1',
+           'autorefresh' => '0',
+           'baseurl' => 'http://packages.vmware.com/tools/esx/latest/sles11.2/x86_64',
+           'path'        => '/',
+           'type'        => 'yum',
+           'gpgcheck' => '1',
+           'gpgkey' => 'http://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub',
+         })
+      }
+    end
+
+    context 'on machine with X installed' do
+      let(:facts) do
+        { :virtual                => 'vmware',
+          :vmware_has_x           => 'true',
+          :operatingsystem        => 'SLES',
+          :lsbmajdistrelease      => '11',
+        }
+      end
+
+      it { should contain_package('vmware-tools-esx-nox').with('ensure' => 'present') }
+
+    end
+  end
+
+  describe 'with defaults for all parameters on OpenSuSE 12 running on vmware' do
+    context 'on machine without X installed' do
+      let(:facts) do
+        { :virtual           => 'vmware',
+          :vmware_has_x      => 'false',
+          :operatingsystem   => 'OpenSuSE',
+          :lsbmajdistrelease => '12',
+        }
+      end
+
+      it { should contain_package('open-vm-tools').with('ensure' => 'present') }
+      it { should_not contain_package('open-vm-tools-desktop') }
+
+      it { should_not contain_package('vmware-tools-esx-nox') }
+      it { should_not contain_package('vmware-tools-esx') }
+      it {
+        should contain_exec('Remove vmware tools script installation').with({
+          'command' => 'installer.sh uninstall',
+          'path' => '/usr/bin/:/etc/vmware-tools/',
+          'onlyif' => 'test -e "/etc/vmware-tools/locations" -a ! -e "/usr/lib/vmware-tools/dsp"',
+        })
+      }
+      it {
+        should_not contain_zypprepo('vmware-osps')
+      }
+    end
+
+    context 'on machine with X installed' do
+      let(:facts) do
+        { :virtual           => 'vmware',
+          :vmware_has_x      => 'true',
+          :operatingsystem   => 'OpenSuSE',
+          :lsbmajdistrelease => '12',
+        }
+      end
+
+      it { should contain_package('open-vm-tools-gui').with('ensure' => 'present') }
+    end
+  end
+
+  describe 'with defaults for all parameters on Ubuntu 12.04 running on vmware' do
+    context 'on machine without X installed' do
+      let(:facts) do
+        { :virtual           => 'vmware',
+          :vmware_has_x      => 'false',
+          :operatingsystem   => 'Ubuntu',
+          :lsbmajdistrelease => '12',
+        }
+      end
+
+      it { should contain_package('open-vm-tools').with('ensure' => 'present') }
+      it { should_not contain_package('open-vm-toolbox') }
+
+      it { should_not contain_package('vmware-tools-esx-nox') }
+      it { should_not contain_package('vmware-tools-esx') }
+      it {
+        should contain_exec('Remove vmware tools script installation').with({
+          'command' => 'installer.sh uninstall',
+          'path' => '/usr/bin/:/etc/vmware-tools/',
+          'onlyif' => 'test -e "/etc/vmware-tools/locations" -a ! -e "/usr/lib/vmware-tools/dsp"',
+        })
+      }
+      it {
+        should_not contain_class('apt')
+      }
+    end
+
+    context 'on machine with X installed' do
+      let(:facts) do
+        { :virtual           => 'vmware',
+          :vmware_has_x      => 'true',
+          :operatingsystem   => 'Ubuntu',
+          :lsbmajdistrelease => '12',
+        }
+      end
+
+      it { should contain_package('open-vm-toolbox').with('ensure' => 'present') }
+    end
+
+    context 'with prefer_open_vm_tools = false' do
+      let(:facts) do
+        { :virtual           => 'vmware',
+          :vmware_has_x      => 'false',
+          :operatingsystem   => 'Ubuntu',
+          :lsbmajdistrelease => '12',
+          :lsbdistid         => 'ubuntu', # for apt
+          :lsbdistcodename   => 'precise',
+        }
+      end
+      let(:params) do
+        { :prefer_open_vm_tools => 'false',
+        }
+      end
+      it { should_not contain_package('open-vm-tools') }
+      it { should_not contain_package('open-vm-toolbox') }
+
+      it { should contain_package('vmware-tools-esx-nox') }
+      it { should_not contain_package('vmware-tools-esx') }
+      it {
+        should contain_exec('Remove vmware tools script installation').with({
+          'command' => 'installer.sh uninstall',
+          'path' => '/usr/bin/:/etc/vmware-tools/',
+          'onlyif' => 'test -e "/etc/vmware-tools/locations" -a ! -e "/usr/lib/vmware-tools/dsp"',
+        })
+      }
+      it {
+        should contain_apt__source('vmware-osps').with({
+            'location'    => 'http://packages.vmware.com/tools/esx/latest/ubuntu',
+            'release'     => 'precise',
+            'repos'       => 'main',
+            'include_src' => false,
+         })
+      }
+    end
+
+  end
+
+  context 'with custom values for parameters on machine running on vmware' do
+    let(:facts) do
+      { :virtual           => 'vmware',
+        :vmware_has_x      => 'true',
+	:operatingsystem   => 'RedHat',
+        :lsbmajdistrelease => '6',
+      }
+    end
+    let(:params) do
+      { :tools_nox_package_name => 'vmware-tools-esx-nox-custom',
+        :tools_nox_package_ensure => '0.2-1',
+        :tools_x_package_name => 'vmware-tools-esx-custom',
+        :tools_x_package_ensure => '0.3-1',
+      }
+    end
+
     it { should contain_package('vmware-tools-esx-nox-custom').with('ensure' => '0.2-1') }
     it { should contain_package('vmware-tools-esx-custom').with('ensure' => '0.3-1') }
-    it { should contain_package('vmware-tools-esx-kmods-custom').with('ensure' => '0.4-1') }
   end
 
   context 'with managing the x package on a machine without x' do
     let(:facts) do
-      { :virtual => 'vmware',
-        :vmware_has_x => 'false',
+      { :virtual           => 'vmware',
+        :vmware_has_x      => 'false',
+	:operatingsystem   => 'RedHat',
+	:lsbmajdistrelease => '6',
       }
     end
     let(:params) do
       { :manage_tools_x_package => 'true',
-        :tools_x_package_name => 'vmware-tools-esx-custom',
+        :tools_x_package_name   => 'vmware-tools-esx-custom',
         :tools_x_package_ensure => '0.5-1',
       }
     end
@@ -153,54 +345,67 @@ describe 'vmware' do
 
   context 'without managing packages' do
     let(:facts) do
-      { :virtual => 'vmware',
+      { :virtual           => 'vmware',
+	:operatingsystem   => 'RedHat',
+	:lsbmajdistrelease => '6',
       }
     end
     let(:params) do
-      { :manage_repo_package => 'false',
-        :manage_tools_nox_package => 'false',
-        :manage_tools_x_package => 'false',
-        :manage_tools_kmod_package => 'false',
+      { :manage_tools_nox_package => 'false',
+        :manage_tools_x_package   => 'false',
       }
     end
 
-    it { should_not contain_package('vmwaretools-key') }
     it { should_not contain_package('vmware-tools-esx') }
     it { should_not contain_package('vmware-tools-esx-nox') }
-    it { should_not contain_package('vmware-tools-esx-kmods') }
     it { should_not contain_exec('Remove vmware tools script installation') }
   end
 
   context 'on a machine that does not run on vmware' do
     let(:facts) do
-      { :virtual => 'physical',
+      { :virtual         => 'physical',
+	:operatingsystem => 'Debian',
+	:lsbmajdistrelease => '7',
       }
     end
 
-    it { should_not contain_package('vmwaretools-key') }
     it { should_not contain_package('vmware-tools-esx') }
     it { should_not contain_package('vmware-tools-esx-nox') }
-    it { should_not contain_package('vmware-tools-esx-kmods') }
     it { should_not contain_exec('Remove vmware tools script installation') }
   end
 
   describe 'with incorrect types' do
     let(:facts) do
-      { :virtual => 'vmware',
+      { :virtual      => 'vmware',
         :vmware_has_x => 'true',
+	:operatingsystem => 'RedHat',
+	:lsbmajdistrelease => '6',
       }
     end
 
-    context 'with manage_repo_package as an array' do
+    context 'with manage_repo as an array' do
       let(:params) do
-        { :manage_repo_package => ['yes'],
+        { :manage_repo => ['no'],
         }
       end
 
       it 'should fail' do
         expect {
           should contain_class('vmware')
-        }.to raise_error(Puppet::Error,/\["yes"\] is not a boolean.  It looks to be a Array/)
+        }.to raise_error(Puppet::Error,/\["no"\] is not a boolean.  It looks to be a Array/)
+      end
+    end
+
+    context 'with prefer_open_vm_tools as an array' do
+      let(:params) do
+        { :prefer_open_vm_tools => ['no'],
+        }
+      end
+
+      it 'should fail' do
+        expect {
+          should contain_class('vmware')
+        }.to raise_error(Puppet::Error,/\["no"\] is not a boolean.  It looks to be a Array/)
       end
     end
 
@@ -230,32 +435,6 @@ describe 'vmware' do
       end
     end
 
-    context 'with manage_tools_kmod_package as an array' do
-      let(:params) do
-        { :manage_tools_kmod_package => ['no'],
-        }
-      end
-
-      it 'should fail' do
-        expect {
-          should contain_class('vmware')
-        }.to raise_error(Puppet::Error,/\["no"\] is not a boolean.  It looks to be a Array/)
-      end
-    end
-
-    context 'with repo_package_name as a bool' do
-      let(:params) do
-        { :repo_package_name => true,
-        }
-      end
-
-      it 'should fail' do
-        expect {
-          should contain_class('vmware')
-        }.to raise_error(Puppet::Error,/true is not a string.  It looks to be a TrueClass/)
-      end
-    end
-
     context 'with tools_nox_package_name as a bool' do
       let(:params) do
         { :tools_nox_package_name => false,
@@ -279,32 +458,6 @@ describe 'vmware' do
         expect {
           should contain_class('vmware')
         }.to raise_error(Puppet::Error,/false is not a string.  It looks to be a FalseClass/)
-      end
-    end
-
-    context 'with tools_kmod_package_name as a bool' do
-      let(:params) do
-        { :tools_kmod_package_name => false,
-        }
-      end
-
-      it 'should fail' do
-        expect {
-          should contain_class('vmware')
-        }.to raise_error(Puppet::Error,/false is not a string.  It looks to be a FalseClass/)
-      end
-    end
-
-    context 'with repo_package_ensure as a bool' do
-      let(:params) do
-        { :repo_package_ensure => true,
-        }
-      end
-
-      it 'should fail' do
-        expect {
-          should contain_class('vmware')
-        }.to raise_error(Puppet::Error,/true is not a string.  It looks to be a TrueClass/)
       end
     end
 
@@ -334,17 +487,5 @@ describe 'vmware' do
       end
     end
 
-    context 'with tools_kmod_package_ensure as a bool' do
-      let(:params) do
-        { :tools_kmod_package_ensure => false,
-        }
-      end
-
-      it 'should fail' do
-        expect {
-          should contain_class('vmware')
-        }.to raise_error(Puppet::Error,/false is not a string.  It looks to be a FalseClass/)
-      end
-    end
   end
 end


### PR DESCRIPTION
This patch fixes the problem that the service was not automatically started on RH7 while installation.
I have positivly tested it with: RedHat 5/6/7, SLES 10/11 & Ubuntu 12/14.

If you don't like to upgrade to stdlib 4.2, `is_bool` can be changed to `is_string`
